### PR TITLE
Fix/allow users to vote once

### DIFF
--- a/src/components/JoinRoom.js
+++ b/src/components/JoinRoom.js
@@ -87,11 +87,9 @@ class JoinRoom extends React.Component {
                     {this.state.rooms.map(room => {
                         var id = room["id"];
                         var is_host = room["is_host"]
-                        if (is_host) { //if that is the host then return the room_id
-                            return (
-                                <span>{id} </span>
-                            )
-                        }
+                        return (
+                            <span>{is_host && id}</span>
+                        )
                     })}
                 </div>
             </div>

--- a/src/components/Queue.js
+++ b/src/components/Queue.js
@@ -31,7 +31,6 @@ function QueueItem(props) {
       user_vote[1] = 0;
       amount = -1;
     }
-    // document.cookie = song_cookie + "=" + user_vote[0] + "_" + user_vote[1]; // update cookie of the song
     setCookie(song_cookie, user_vote[0] + "_" + user_vote[1], 4);
     
     let payload = { index: index, amount: amount };
@@ -59,7 +58,6 @@ function QueueItem(props) {
       user_vote[1] = -1;
       amount = -2;
     }
-    // document.cookie = song_cookie + "=" + user_vote[0] + "_" + user_vote[1]; // update cookie of the song
     setCookie(song_cookie, user_vote[0] + "_" + user_vote[1], 4);
     let payload = { index: index, amount: amount };
     api.vote(room_id, payload)
@@ -81,7 +79,6 @@ function QueueItem(props) {
       user_vote[0] = 0;
       amount = -1;
     }
-    // document.cookie = song_cookie + "=" + user_vote[0] + "_" + user_vote[1]; // update cookie of the song
     setCookie(song_cookie, user_vote[0] + "_" + user_vote[1], 4);
     let payload = { index: index, amount: amount };
     api.report(room_id, payload)
@@ -92,7 +89,9 @@ function QueueItem(props) {
   /* Rendering className of report/like/dislike button based on props.user_vote */
   const songInfo = props.songInfo;
   const song_cookie = props.room_id + "_" + props.id;
-  let LIKE_CLASS, DISLIKE_CLASS, REPORT_CLASS;
+  let LIKE_CLASS = "like";
+  let DISLIKE_CLASS = "dislike";
+  let REPORT_CLASS = "report";
   if (props.user_vote !== undefined) {
     if (props.user_vote[1] === -1) {
       LIKE_CLASS = "like";

--- a/src/components/Room.js
+++ b/src/components/Room.js
@@ -81,7 +81,7 @@ class Room extends React.Component {
      * when the page is reloaded 
      */
     updateSongCookie(room_id, queue) {
-        let votes_prv = {};
+        let store = {};
         // get all the cookies that corresponds to songs in the room: room_id + "_" + song_id + "=" + report + "_" + vote
         let decodedCookie = decodeURIComponent(document.cookie);
         let ca = decodedCookie.split(';');
@@ -95,17 +95,17 @@ class Room extends React.Component {
                     let song_cookie = c.substring(0, c.length - 5);
                     let report = parseInt(c.charAt(c.length - 4));
                     let vote = (-1) * parseInt(c.substring(c.length - 1));
-                    votes_prv[song_cookie] = [report,vote];
+                    store[song_cookie] = [report,vote];
                 }
                 else { // positive vote
                     let song_cookie = c.substring(0, c.length - 4);
                     let report = parseInt(c.charAt(c.length - 3));
                     let vote = parseInt(c.substring(c.length - 1));
-                    votes_prv[song_cookie] = [report,vote];
+                    store[song_cookie] = [report,vote];
                 }
             }
         }
-        console.log("user_votes before queue update (retrieved from cookies): ", votes_prv)
+        console.log("store of votes (retrieved from cookies): ", store)
         // get all the song_ids in the current queue
         let entries_cur = [];
         for (let i = 0; i < queue.length; i++) {
@@ -119,16 +119,16 @@ class Room extends React.Component {
         // check for new songs and delete songs that are no longer in queue
         for (let i = 0; i < entries_cur.length; i++) {
             let song_cookie = entries_cur[i];
-            if (votes_prv[song_cookie] !== undefined) { // if song_ids in current queue are already saved in cookies
-                user_votes[song_cookie] = votes_prv[song_cookie];
-                delete votes_prv[song_cookie];
+            if (store[song_cookie] !== undefined) { // if song_ids in current queue are already saved in cookies
+                user_votes[song_cookie] = store[song_cookie];
+                delete store[song_cookie];
             }
             else { // new songs
                 user_votes[song_cookie] = [0,0];
                 this.setCookie(song_cookie, '0_0', 4);
             }
         }
-        let entries_prv = Object.keys(votes_prv); // an array of song_ids no longer in queue
+        let entries_prv = Object.keys(store); // an array of song_ids no longer in queue
         for (let i = 0; i < entries_prv.length; i++) {
             console.log("song_cookie to be deleted: " + entries_prv[i]);
             this.setCookie(entries_prv[i], "", 1 / 3600); // delete the corresponding cookie of songs that are no longer in queue

--- a/src/components/Room.js
+++ b/src/components/Room.js
@@ -59,7 +59,7 @@ class Room extends React.Component {
     componentDidMount() {
         // wait until fetchRoom returns before doing other operations that are dependent on the room state
         this.fetchRoom(this.state.room_id);
-        
+
         // subscribe to pusher channel that corresponds to the room_id
         this.pusher = new Pusher(pusher_key, {
             cluster: pusher_cluster,
@@ -101,12 +101,9 @@ class Room extends React.Component {
                     let vote = parseInt(c.substring(c.length - 1));
                     store[song_cookie] = [report, vote];
                 }
-                else { // if the cookie stored is not the supported format
-                    alert("Please clear cookies stored on this site");
-                }
             }
         }
-        console.log("store of votes (retrieved from cookies): ", store)
+        // console.log("store of votes (retrieved from cookies): ", store)
         // get all the song_ids in the current queue
         let entries_cur = [];
         for (let i = 0; i < queue.length; i++) {
@@ -114,7 +111,7 @@ class Room extends React.Component {
             let song_cookie = room_id + "_" + song_id;
             entries_cur.push(song_cookie);
         }
-        console.log("current song_cookies of songs in queue (retrieved from queue property): ", entries_cur)
+        // console.log("current song_cookies of songs in queue (retrieved from queue property): ", entries_cur)
         let user_votes = {};
 
         // check for new songs and delete songs that are no longer in queue
@@ -131,10 +128,10 @@ class Room extends React.Component {
         }
         let entries_prv = Object.keys(store); // an array of song_ids no longer in queue
         for (let i = 0; i < entries_prv.length; i++) {
-            console.log("song_cookie to be deleted: " + entries_prv[i]);
+            // console.log("song_cookie to be deleted: " + entries_prv[i]);
             this.setCookie(entries_prv[i], "", 1 / 3600); // delete the corresponding cookie of songs that are no longer in queue
         }
-        console.log("new user_votes property of room: ", user_votes);
+        // console.log("new user_votes property of room: ", user_votes);
         return user_votes;
     }
 
@@ -224,7 +221,7 @@ class Room extends React.Component {
     addDefaultPlaylist(playlist) {
         const payload = { default_playlist: playlist }
         api.addPlaylist(this.state.room_id, payload)
-            .then(() => console.log("Successfully updated"))
+            .then(() => console.log("Default Playlist successfully updated"))
             .catch(err => console.log(err));
     }
 
@@ -260,7 +257,7 @@ class Room extends React.Component {
             song.vote = 0;
             song.report = 0;
             api.addToQueue(this.state.room_id, song)
-                .then(() => console.log("Successfully added"))
+                .then(() => console.log("Song successfully added"))
                 .catch(err => console.log(err));
         }
     }
@@ -314,7 +311,6 @@ class Room extends React.Component {
                     .then(res => {
                         const playlist = res.tracks.items;
                         var position = Math.floor(Math.random() * playlist.length);
-                        console.log(position);
                         var nextSongURI = playlist[position].track.uri;
                         options = {
                             uris: [nextSongURI],

--- a/src/components/Room.js
+++ b/src/components/Room.js
@@ -91,7 +91,7 @@ class Room extends React.Component {
                 c = c.substring(1);
             }
             if (c.indexOf(room_id) === 0) { //if the cookie corresponds to a song in the room
-                if (c.charAt(c.length - 2) === '-') { // negative vote
+                if (c.charAt(c.length - 2) === '-' && c.charAt(c.length - 3) === '_') { // negative vote
                     let song_cookie = c.substring(0, c.length - 5);
                     let report = parseInt(c.charAt(c.length - 4));
                     let vote = (-1) * parseInt(c.substring(c.length - 1));

--- a/src/components/Room.js
+++ b/src/components/Room.js
@@ -26,6 +26,7 @@ class Room extends React.Component {
             room_id: params.room_id,
             hostInfo: {},
             queue: [],
+            user_votes: {},
             default_playlist: null,
             nowPlaying: {
                 playing: false,
@@ -51,10 +52,15 @@ class Room extends React.Component {
         this.updateNowPlaying = this.updateNowPlaying.bind(this);
         this.updateQueue = this.updateQueue.bind(this);
         this.updateDefaultPlaylist = this.updateDefaultPlaylist.bind(this);
+
+        this.updateSongCookie = this.updateSongCookie.bind(this);
     }
 
-    componentDidMount() {
-        this.fetchRoom(this.state.room_id);
+    async componentDidMount() {
+        // wait until fetchRoom returns before doing other operations that are dependent on the room state
+        await this.fetchRoom(this.state.room_id);
+
+        this.updateSongCookie(this.state.room_id, this.state.queue);
 
         // subscribe to pusher channel that corresponds to the room_id
         this.pusher = new Pusher(pusher_key, {
@@ -68,6 +74,69 @@ class Room extends React.Component {
         this.channel.bind('updateQueue', this.updateQueue);
         this.channel.bind('updateDefaultPlaylist', this.updateDefaultPlaylist);
 
+    }
+
+    /**
+     * Update cookie that corresponds to a song in a room, this function is to be called when an updateQueue event happens or 
+     * when the page is reloaded 
+     */
+    updateSongCookie(room_id, queue) {
+        let votes_prv = {};
+        // get all the cookies that corresponds to songs in the room: room_id + "_" + song_id + "=" + report + "_" + vote
+        let decodedCookie = decodeURIComponent(document.cookie);
+        let ca = decodedCookie.split(';');
+        for (let i = 0; i < ca.length; i++) {
+            let c = ca[i];
+            while (c.charAt(0) === ' ') { // stripping whitespace
+                c = c.substring(1);
+            }
+            if (c.indexOf(room_id) === 0) { //if the cookie corresponds to a song in the room
+                if (c[c.length - 2] === '-') { // negative vote
+                    let song_cookie = c.substring(0, c.length - 5);
+                    let report = parseInt(c.charAt(c.length - 4));
+                    let vote = (-1) * parseInt(c.substring(c.length - 1));
+                    votes_prv[song_cookie] = [report,vote];
+                }
+                else { // positive vote
+                    let song_cookie = c.substring(0, c.length - 4);
+                    let report = parseInt(c.charAt(c.length - 3));
+                    let vote = parseInt(c.substring(c.length - 1));
+                    votes_prv[song_cookie] = [report,vote];
+                }
+            }
+        }
+        console.log("user_votes before queue update (retrieved from cookies): ", votes_prv)
+        // get all the song_ids in the current queue
+        let entries_cur = [];
+        for (let i = 0; i < queue.length; i++) {
+            let song_id = queue[i].id;
+            let song_cookie = room_id + "_" + song_id;
+            entries_cur.push(song_cookie);
+        }
+        console.log("current song_cookies of songs in queue (retrieved from queue property): ", entries_cur)
+        let user_votes = {};
+        
+        // check for new songs and delete songs that are no longer in queue
+        for (let i = 0; i < entries_cur.length; i++) {
+            let song_cookie = entries_cur[i];
+            if (votes_prv[song_cookie] !== undefined) { // if song_ids in current queue are already saved in cookies
+                user_votes[song_cookie] = votes_prv[song_cookie];
+                delete votes_prv[song_cookie];
+            }
+            else { // new songs
+                user_votes[song_cookie] = [0,0];
+                this.setCookie(song_cookie, '0_0', 4);
+            }
+        }
+        let entries_prv = Object.keys(votes_prv); // an array of song_ids no longer in queue
+        for (let i = 0; i < entries_prv.length; i++) {
+            console.log("song_cookie to be deleted: " + entries_prv[i]);
+            this.setCookie(entries_prv[i], "", 1 / 3600); // delete the corresponding cookie of songs that are no longer in queue
+        }
+        console.log("new user_votes property of room: ", user_votes);
+        this.setState({
+            user_votes: user_votes
+        })
     }
 
     /**
@@ -87,8 +156,9 @@ class Room extends React.Component {
      */
     updateQueue(data) {
         let queue = data.queue;
+        this.updateSongCookie(this.state.room_id, queue);
         this.setState({
-            queue: queue
+            queue: queue,
         })
     }
 
@@ -107,8 +177,8 @@ class Room extends React.Component {
      * Fetch the room info and update room state 
      * @param {String} room_id
      */
-    fetchRoom(room_id) {
-        api.getRoom(room_id)
+    async fetchRoom(room_id) {
+        await api.getRoom(room_id)
             .then(res => {
                 if (res.data.success) {
                     const room = res.data.data;
@@ -158,7 +228,7 @@ class Room extends React.Component {
 
     addToQueue(search) {
         if (this.state.queue.length >= MAX_SONG_IN_QUEUE) alert("Our queue can only contain a maximum of " + MAX_SONG_IN_QUEUE + " songs.");
-        else{
+        else {
             let song = {};
             // get the name of all artists
             let artists = [];
@@ -283,12 +353,14 @@ class Room extends React.Component {
      * @param {number} exhrs: time expired (in hours) - not setting the expire time for now
      * 
      */
-    setCookie(cname, cvalue, exhrs) {
-        var d = new Date();
-        d.setTime(d.getTime() + (exhrs * 60 * 60 * 1000));
-        // var expires = "expires=" + d.toUTCString();
-        // document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
-        document.cookie = cname + "=" + cvalue;
+    setCookie(cname, cvalue, exhrs = null) {
+        if (exhrs !== null) {
+            var d = new Date();
+            d.setTime(d.getTime() + (exhrs * 60 * 60 * 1000));
+            var expires = "expires=" + d.toUTCString();
+            document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+        }
+        else document.cookie = cname + "=" + cvalue;
     }
 
     /**
@@ -369,7 +441,9 @@ class Room extends React.Component {
                             queue={this.state.queue}
                             room_id={this.state.room_id}
                             is_host={this.state.is_host}
-                            play={this.play} />
+                            play={this.play}
+                            setCookie = {this.setCookie}
+                            user_votes={this.state.user_votes} />
                     </div>
                 </div>
                 {this.state.is_host &&

--- a/src/components/Room.js
+++ b/src/components/Room.js
@@ -91,17 +91,20 @@ class Room extends React.Component {
                 c = c.substring(1);
             }
             if (c.indexOf(room_id) === 0) { //if the cookie corresponds to a song in the room
-                if (c[c.length - 2] === '-') { // negative vote
+                if (c.charAt(c.length - 2) === '-') { // negative vote
                     let song_cookie = c.substring(0, c.length - 5);
                     let report = parseInt(c.charAt(c.length - 4));
                     let vote = (-1) * parseInt(c.substring(c.length - 1));
-                    store[song_cookie] = [report,vote];
+                    store[song_cookie] = [report, vote];
                 }
-                else { // positive vote
+                else if (c.charAt(c.length - 2) === '_') { // positive vote
                     let song_cookie = c.substring(0, c.length - 4);
                     let report = parseInt(c.charAt(c.length - 3));
                     let vote = parseInt(c.substring(c.length - 1));
-                    store[song_cookie] = [report,vote];
+                    store[song_cookie] = [report, vote];
+                }
+                else {
+                    alert("Please clear cookies stored on this site");
                 }
             }
         }
@@ -115,7 +118,7 @@ class Room extends React.Component {
         }
         console.log("current song_cookies of songs in queue (retrieved from queue property): ", entries_cur)
         let user_votes = {};
-        
+
         // check for new songs and delete songs that are no longer in queue
         for (let i = 0; i < entries_cur.length; i++) {
             let song_cookie = entries_cur[i];
@@ -124,7 +127,7 @@ class Room extends React.Component {
                 delete store[song_cookie];
             }
             else { // new songs
-                user_votes[song_cookie] = [0,0];
+                user_votes[song_cookie] = [0, 0];
                 this.setCookie(song_cookie, '0_0', 4);
             }
         }
@@ -442,7 +445,7 @@ class Room extends React.Component {
                             room_id={this.state.room_id}
                             is_host={this.state.is_host}
                             play={this.play}
-                            setCookie = {this.setCookie}
+                            setCookie={this.setCookie}
                             user_votes={this.state.user_votes} />
                     </div>
                 </div>

--- a/src/components/Room.js
+++ b/src/components/Room.js
@@ -59,13 +59,7 @@ class Room extends React.Component {
     componentDidMount() {
         // wait until fetchRoom returns before doing other operations that are dependent on the room state
         this.fetchRoom(this.state.room_id);
-
-        // let user_votes = this.updateSongCookie(this.state.room_id, this.state.queue);
-
-        // this.setState({
-        //     user_votes: user_votes
-        // })
-
+        
         // subscribe to pusher channel that corresponds to the room_id
         this.pusher = new Pusher(pusher_key, {
             cluster: pusher_cluster,
@@ -141,9 +135,6 @@ class Room extends React.Component {
             this.setCookie(entries_prv[i], "", 1 / 3600); // delete the corresponding cookie of songs that are no longer in queue
         }
         console.log("new user_votes property of room: ", user_votes);
-        // this.setState({
-        //     user_votes: user_votes
-        // })
         return user_votes;
     }
 

--- a/src/style/Room.css
+++ b/src/style/Room.css
@@ -195,9 +195,7 @@ html {
   font-size: 1.2em;
 }
 
-
-
-.like:hover, .liked {
+.liked {
   color: #6BE193;
   font-size: 1.2em;
 }
@@ -207,7 +205,7 @@ html {
   font-size: 1.2em;
 }
 
-.dislike:hover, .disliked{
+.disliked{
   color:#6BE193;
   font-size: 1.2em;
 }
@@ -217,7 +215,7 @@ html {
   font-size: 1.2em;
 }
 
-.report:hover, .reported{
+.reported{
   color:red;
   font-size: 1.2em;
 }

--- a/src/style/Room.css
+++ b/src/style/Room.css
@@ -191,9 +191,6 @@ html {
 }
 
 .like{
-  /* border: 2px solid #6BE193;
-  border-radius: 25px; */
-  /* width: 75px; */
   color: white;
   font-size: 1.2em;
 }
@@ -201,32 +198,28 @@ html {
 
 
 .like:hover, .liked {
-  /* background-color: #6BE193; */
   color: #6BE193;
+  font-size: 1.2em;
 }
 
 .dislike{
-  /* border: 2px solid gray;
-  border-radius: 20px; */
   color: white;
   font-size: 1.2em;
 }
 
 .dislike:hover, .disliked{
-  /* background-color: grey; */
   color:#6BE193;
+  font-size: 1.2em;
 }
 
 .report{
-  /* border: 2px solid red;
-  border-radius: 20px; */
   color: white;
   font-size: 1.2em;
 }
 
 .report:hover, .reported{
-  /* background-color: red; */
   color:red;
+  font-size: 1.2em;
 }
 
 .queue-container #coming_up{


### PR DESCRIPTION
This PR does:
- use `updateSongCookie()` to retrieve and update cookies that correspond to the current songs in the queue
- `updateSongCookie()` is called in `fetchRoom()` and `updateQueue()`
- make song item buttons update based on `user_votes` field property room's state which store the cookies and their values of the songs in the queue